### PR TITLE
Fix: Keyboard changed to email type where necessary

### DIFF
--- a/mentorship ios/Views/Registration/Login.swift
+++ b/mentorship ios/Views/Registration/Login.swift
@@ -22,6 +22,7 @@ struct Login: View {
                 TextField("Username/Email", text: $loginViewModel.loginData.username)
                     .textFieldStyle(RoundFilledTextFieldStyle())
                     .autocapitalization(.none)
+                    .keyboardType(.emailAddress)
 
                 SecureField("Password", text: $loginViewModel.loginData.password)
                     .textFieldStyle(RoundFilledTextFieldStyle())

--- a/mentorship ios/Views/Registration/SignUp.swift
+++ b/mentorship ios/Views/Registration/SignUp.swift
@@ -23,6 +23,7 @@ struct SignUp: View {
                         TextField("Email", text: $signUpViewModel.signUpData.email)
                             .textFieldStyle(RoundFilledTextFieldStyle())
                             .autocapitalization(.none)
+                            .keyboardType(.emailAddress)
                         SecureField("Password", text: $signUpViewModel.signUpData.password)
                             .textFieldStyle(RoundFilledTextFieldStyle())
                         SecureField("Confirm Password", text: $signUpViewModel.confirmPassword)


### PR DESCRIPTION
### Description
This PR changes keyboard type to email for email text fields in Login and Signup Views.

Fixes #65 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- This feature changes the keyboard type to email for email text fields in Login and Signup Views

### How Has This Been Tested?
XCode

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
