### PR TITLE
fix: unwanted message text is not shown on add task screen now

### DIFF
--- a/mentorship ios.xcodeproj/project.pbxproj
+++ b/mentorship ios.xcodeproj/project.pbxproj
@@ -987,7 +987,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"mentorship ios/Preview Content\"";
-				DEVELOPMENT_TEAM = ZCF7ZR4CVF;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "mentorship ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1007,7 +1007,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"mentorship ios/Preview Content\"";
-				DEVELOPMENT_TEAM = ZCF7ZR4CVF;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "mentorship ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/mentorship ios/Models/RelationModel.swift
+++ b/mentorship ios/Models/RelationModel.swift
@@ -15,7 +15,7 @@ class RelationModel {
     
     // MARK: - Structures
     struct ResponseData: Encodable {
-        let message: String?
+        var message: String?
         let success: Bool
     }
     

--- a/mentorship ios/ViewModels/RelationViewModel.swift
+++ b/mentorship ios/ViewModels/RelationViewModel.swift
@@ -51,6 +51,13 @@ class RelationViewModel: ObservableObject {
     }
     
     // MARK: - Functions
+    
+    // resets values in add task screen. Used in onAppear modifier in the view
+    func resetDataForAddTaskScreen() {
+        newTask.description = ""
+        responseData.message = ""
+    }
+    
     func handleFetchedTasks(tasks: [TaskStructure], success: Bool) {
         if success {
             doneTasks.removeAll()

--- a/mentorship ios/Views/Relation/AddTask.swift
+++ b/mentorship ios/Views/Relation/AddTask.swift
@@ -55,7 +55,8 @@ struct AddTask: View {
                 self.presentationMode.wrappedValue.dismiss()
             })
             .onAppear {
-                self.relationViewModel.newTask.description = ""
+                // reset the new task description and error message desc to ""
+                self.relationViewModel.resetDataForAddTaskScreen()
             }
         }
     }

--- a/mentorship iosTests/RelationTests.swift
+++ b/mentorship iosTests/RelationTests.swift
@@ -130,6 +130,21 @@ class RelationTests: XCTestCase {
     
     // MARK: - RelationViewModel tests
     
+    func testResetDataForAddTaskScreen() {
+        let relationVM = RelationViewModel()
+        
+        // set some values to response and new task description
+        relationVM.newTask.description = "test"
+        relationVM.responseData.message = "message"
+        
+        // reset
+        relationVM.resetDataForAddTaskScreen()
+        
+        // Test
+        XCTAssertEqual(relationVM.newTask.description.isEmpty, true)
+        XCTAssertEqual(relationVM.responseData.message?.isEmpty, true)
+    }
+    
     func testPersonNameAndType() {
         let relationVM = RelationViewModel()
         


### PR DESCRIPTION
### Description
This PR fixes the bug where the message text of task achieved was visible on the add task screen. Unit test has been added.

Fixes #103 

### Type of Change:
- Code
- Quality Assurance
- User Interface
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on simulator

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
