### PR TITLE
fix: members list screen status bar color fixed

### DIFF
--- a/mentorship ios.xcodeproj/project.pbxproj
+++ b/mentorship ios.xcodeproj/project.pbxproj
@@ -987,7 +987,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"mentorship ios/Preview Content\"";
-				DEVELOPMENT_TEAM = ZCF7ZR4CVF;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "mentorship ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1007,7 +1007,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"mentorship ios/Preview Content\"";
-				DEVELOPMENT_TEAM = ZCF7ZR4CVF;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "mentorship ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/mentorship ios/Views/Members/Members.swift
+++ b/mentorship ios/Views/Members/Members.swift
@@ -68,6 +68,7 @@ struct Members: View {
             }
             .navigationBarTitle(LocalizableStringConstants.ScreenNames.members)
         }
+        .edgesIgnoringSafeArea(.top)
     }
 }
 


### PR DESCRIPTION
### Description
This PR fixes the bug where the status bar in the members list screen had a different color than the navigation view.

Fixes #116 

### Mocks
| Earlier | Now |
| ------ | ----- |
<img width="501" alt="Screen Shot 2020-08-20 at 4 48 14 PM" src="https://user-images.githubusercontent.com/31164725/90764408-ea17ee80-e305-11ea-9a3a-ad87a660ea34.png"> | <img width="501" alt="Screen Shot 2020-08-20 at 4 54 06 PM" src="https://user-images.githubusercontent.com/31164725/90764363-d9677880-e305-11ea-9660-c14d8bbc6e4b.png">

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on simulator

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
