### PR TITLE
reset login data when view disappear- Fix for #125

### DIFF
--- a/mentorship ios/ViewModels/LoginViewModel.swift
+++ b/mentorship ios/ViewModels/LoginViewModel.swift
@@ -30,5 +30,11 @@ class LoginViewModel: ObservableObject {
     func attemptAppleLogin() {
         appleSignInCoordinator.handleAuthorizationAppleIDButtonPress()
     }
+
+    //reset tthe login data when the view is going to disappear
+    //fix for:https://github.com/anitab-org/mentorship-ios/issues/125
+    func resetLogin() {
+        self.loginData = .init(username: "", password: "")
+    }
     
 }

--- a/mentorship ios/Views/Registration/Login.swift
+++ b/mentorship ios/Views/Registration/Login.swift
@@ -99,6 +99,9 @@ struct Login: View {
                 .frame(height: DesignConstants.Height.socialSignInButton)
             }
         }
+        .onDisappear {
+            self.loginViewModel.resetLogin()
+        }
         .modifier(AllPadding())
     }
 }


### PR DESCRIPTION



### Description
 when login view is going to disappear, login data we should reset the login data, to avoid the appearance for it again when the user logs out, as a fix for this [bug](https://github.com/anitab-org/mentorship-ios/issues/125)

result 
 ![](https://i.imgur.com/XbQ8teh.gif)

Fixes # [125]


### Type of Change:
**Delete irrelevant options.**

- Code
 - User Interface
 
**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
all tests passed, it doesn't affect them. 


### Checklist:
**Delete irrelevant options.**

 
**Code/Quality Assurance Only**
 - [ ] I have added tests that prove my fix is effective or that my feature works
 