### PR TITLE
Change password error not seen on success

### DIFF
--- a/mentorship ios/Views/Settings/IndividualSetting/ChangePassword.swift
+++ b/mentorship ios/Views/Settings/IndividualSetting/ChangePassword.swift
@@ -62,6 +62,7 @@ struct ChangePassword: View {
                 dismissButton: .default(Text(LocalizableStringConstants.okay)) {
                     //pop navigation view after okay button pressed
                     self.presentationMode.wrappedValue.dismiss()
+                    self.changePasswordViewModel.changePasswordResponseData.success = true
                 })
         }
     }


### PR DESCRIPTION
### Description
ChangePassword error label not seen on success now.

Fixes #134 

### Preview:

<image src = "https://user-images.githubusercontent.com/53724307/93416833-3f72fb80-f8c4-11ea-8c91-62d35b1437cd.gif" width = "200" >

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Xcode Simulator.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)

  This pr contains a bug which will be resolved in the pr for issue #135 