### PR TITLE
fix: Change password fields reset upon dismissal.

### DIFF
--- a/mentorship ios/ViewModels/ChangePasswordViewModel.swift
+++ b/mentorship ios/ViewModels/ChangePasswordViewModel.swift
@@ -21,4 +21,10 @@ class ChangePasswordViewModel: ObservableObject {
         }
         return false
     }
+    
+    func resetData(){
+        self.changePasswordData = ChangePasswordModel.ChangePasswordUploadData(currentPassword: "", newPassword: "")
+        self.changePasswordResponseData = ChangePasswordModel.ChangePasswordResponseData(message: "", success: false)
+        self.confirmPassword = ""
+    }
 }

--- a/mentorship ios/Views/Settings/IndividualSetting/ChangePassword.swift
+++ b/mentorship ios/Views/Settings/IndividualSetting/ChangePassword.swift
@@ -64,6 +64,9 @@ struct ChangePassword: View {
                     self.presentationMode.wrappedValue.dismiss()
                 })
         }
+        .onDisappear {
+            self.changePasswordViewModel.resetData()
+        }
     }
 }
 

--- a/mentorship iosTests/SettingsTests.swift
+++ b/mentorship iosTests/SettingsTests.swift
@@ -136,7 +136,7 @@ class SettingsTests: XCTestCase {
         // Set mock data
         changePasswordVM.changePasswordData = ChangePasswordModel.ChangePasswordUploadData(currentPassword: "old", newPassword: "new")
         changePasswordVM.confirmPassword = "new"
-        changePasswordVM.changePasswordResponseData = ChangePasswordModel.ChangePasswordResponseData(message: "", success: false)
+        changePasswordVM.changePasswordResponseData = ChangePasswordModel.ChangePasswordResponseData(message: "test", success: true)
 
         // reset data of View Model
         changePasswordVM.resetData()

--- a/mentorship iosTests/SettingsTests.swift
+++ b/mentorship iosTests/SettingsTests.swift
@@ -127,4 +127,25 @@ class SettingsTests: XCTestCase {
         
         wait(for: [expectation], timeout: 1)
     }
+    
+    func testChangePasswordReset() throws {
+        
+        // View Model
+        let changePasswordVM = ChangePasswordViewModel()
+
+        // Set mock data
+        changePasswordVM.changePasswordData = ChangePasswordModel.ChangePasswordUploadData(currentPassword: "old", newPassword: "new")
+        changePasswordVM.confirmPassword = "new"
+        changePasswordVM.changePasswordResponseData = ChangePasswordModel.ChangePasswordResponseData(message: "", success: false)
+
+        // reset data of View Model
+        changePasswordVM.resetData()
+
+        // test
+        XCTAssertEqual("", changePasswordVM.changePasswordData.currentPassword)
+        XCTAssertEqual("", changePasswordVM.changePasswordData.newPassword)
+        XCTAssertEqual("", changePasswordVM.confirmPassword)
+        XCTAssertEqual("", changePasswordVM.changePasswordResponseData.message)
+        XCTAssertEqual(false, changePasswordVM.changePasswordResponseData.success)
+    }
 }

--- a/mentorship iosTests/SettingsTests.swift
+++ b/mentorship iosTests/SettingsTests.swift
@@ -128,8 +128,7 @@ class SettingsTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
     
-    func testChangePasswordReset() throws {
-        
+    func testChangePasswordReset() {
         // View Model
         let changePasswordVM = ChangePasswordViewModel()
 


### PR DESCRIPTION
### Description
The textfields and error label of ChangePassword view reset upon dismissal.
Fixes #135 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### Preview:

<image src = "https://user-images.githubusercontent.com/53724307/93472772-c51d9800-f912-11ea-9eaf-6c4f15475710.png" width = "200">


### How Has This Been Tested?
Xcode Simulator.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 