### PR TITLE
[#139] Add a validation to enable/disable the save button of the Edit Profile view

### DIFF
--- a/mentorship ios/Views/Profile/ProfileEditor.swift
+++ b/mentorship ios/Views/Profile/ProfileEditor.swift
@@ -12,6 +12,13 @@ struct ProfileEditor: View {
     @State var editProfileData = ProfileViewModel().getEditProfileData()
     @ObservedObject var profileViewModel = ProfileViewModel()
     
+    var canSave:Bool {
+        guard let name = $editProfileData.name.wrappedValue, name.isEmpty == false else {
+            return false
+        }
+        return true
+    }
+    
     // make api call to update profile
     func updateProfile() {
         self.profileService.updateProfile(updateProfileData: self.editProfileData) { response in
@@ -30,14 +37,6 @@ struct ProfileEditor: View {
                 self.profileViewModel.alertTitle = LocalizableStringConstants.failure
             }
         }
-    }
-    
-    func isValidForm() -> Bool {
-        guard let name = $editProfileData.name.wrappedValue, name.isEmpty == false else {
-            return false
-        }
-        
-        return true
     }
     
     var body: some View {
@@ -87,7 +86,7 @@ struct ProfileEditor: View {
                     self.profileViewModel.inActivity = true
                     // make network call to update profile
                     self.updateProfile()
-                }.disabled(isValidForm() == false))
+                }.disabled(self.canSave == false))
             .alert(isPresented: $profileViewModel.showAlert) {
                 Alert.init(
                     title: Text(profileViewModel.alertTitle),

--- a/mentorship ios/Views/Profile/ProfileEditor.swift
+++ b/mentorship ios/Views/Profile/ProfileEditor.swift
@@ -13,10 +13,7 @@ struct ProfileEditor: View {
     @ObservedObject var profileViewModel = ProfileViewModel()
     
     var canSave:Bool {
-        guard let name = $editProfileData.name.wrappedValue, name.isEmpty == false else {
-            return false
-        }
-        return true
+        return (self.editProfileData.name ?? "").isEmpty == false
     }
     
     // make api call to update profile

--- a/mentorship ios/Views/Profile/ProfileEditor.swift
+++ b/mentorship ios/Views/Profile/ProfileEditor.swift
@@ -32,6 +32,14 @@ struct ProfileEditor: View {
         }
     }
     
+    func isValidForm() -> Bool {
+        guard let name = $editProfileData.name.wrappedValue, name.isEmpty == false else {
+            return false
+        }
+        
+        return true
+    }
+    
     var body: some View {
         NavigationView {
             ZStack {
@@ -79,7 +87,7 @@ struct ProfileEditor: View {
                     self.profileViewModel.inActivity = true
                     // make network call to update profile
                     self.updateProfile()
-                })
+                }.disabled(isValidForm() == false))
             .alert(isPresented: $profileViewModel.showAlert) {
                 Alert.init(
                     title: Text(profileViewModel.alertTitle),

--- a/mentorship iosTests/ProfileTests.swift
+++ b/mentorship iosTests/ProfileTests.swift
@@ -148,33 +148,24 @@ class ProfileTests: XCTestCase {
         XCTAssertEqual(profileVM.getProfile().name, "newName")
     }
     
-    func testCanSaveProfileWithoutNameAndFail() throws {
+    func testSaveButtonDisableState() {
         // Profile Service
         let profileService: ProfileService = ProfileAPI(urlSession: urlSession)
         
         // View Model
-        let sampleData = ProfileModel.ProfileData(id: 0, name: "", username: "", email: "")
+        var sampleData = ProfileModel.ProfileData(id: 0, name: "", username: "", email: "")
         let profileVM = ProfileViewModel()
         profileVM.saveProfile(profile: sampleData)
         
         // Profile Editor View
-        let profileEditor = ProfileEditor(profileService: profileService, profileViewModel: profileVM)
+        var profileEditor = ProfileEditor(profileService: profileService, profileViewModel: profileVM)
         
         XCTAssertFalse(profileEditor.canSave)
-    }
-    
-    func testCanSaveProfileWithNameAndSucceed() throws {
-        // Profile Service
-        let profileService: ProfileService = ProfileAPI(urlSession: urlSession)
         
-        // View Model
-        let sampleData = ProfileModel.ProfileData(id: 0, name: "name", username: "", email: "")
-        let profileVM = ProfileViewModel()
+        sampleData =  ProfileModel.ProfileData(id: 0, name: "name", username: "", email: "")
         profileVM.saveProfile(profile: sampleData)
         
-        // Profile Editor View
-        let profileEditor = ProfileEditor(profileService: profileService, profileViewModel: profileVM)
-        
+        profileEditor = ProfileEditor(profileService: profileService, profileViewModel: profileVM)
         XCTAssertTrue(profileEditor.canSave)
     }
     

--- a/mentorship iosTests/ProfileTests.swift
+++ b/mentorship iosTests/ProfileTests.swift
@@ -14,7 +14,7 @@ class ProfileTests: XCTestCase {
     var urlSession: URLSession!
     
     // MARK: - Setup and Tear Down
-
+    
     override func setUpWithError() throws {
         // Set url session for mock networking
         let configuration = URLSessionConfiguration.ephemeral
@@ -25,7 +25,7 @@ class ProfileTests: XCTestCase {
         // api calls require a token, otherwise tests fail
         try KeychainManager.setToken(username: "", tokenString: "")
     }
-
+    
     override func tearDownWithError() throws {
         urlSession = nil
         try KeychainManager.deleteToken()
@@ -86,7 +86,7 @@ class ProfileTests: XCTestCase {
     
     func testSaveAndGetProfile() {
         let profileVM = ProfileViewModel()
-
+        
         //save sample data
         profileVM.saveProfile(profile: sampleProfileData)
         
@@ -100,7 +100,7 @@ class ProfileTests: XCTestCase {
     
     func testEditProfileDataReceived() {
         let profileVM = ProfileViewModel()
-
+        
         //prepare sample data
         let sampleData = ProfileModel.ProfileData(id: 100, name: nil, username: "username", email: "test@abc.com")
         
@@ -146,6 +146,36 @@ class ProfileTests: XCTestCase {
         
         // Test the profile has been updated
         XCTAssertEqual(profileVM.getProfile().name, "newName")
+    }
+    
+    func testCanSaveProfileWithoutNameAndFail() throws {
+        // Profile Service
+        let profileService: ProfileService = ProfileAPI(urlSession: urlSession)
+        
+        // View Model
+        let sampleData = ProfileModel.ProfileData(id: 0, name: "", username: "", email: "")
+        let profileVM = ProfileViewModel()
+        profileVM.saveProfile(profile: sampleData)
+        
+        // Profile Editor View
+        let profileEditor = ProfileEditor(profileService: profileService, profileViewModel: profileVM)
+        
+        XCTAssertFalse(profileEditor.canSave)
+    }
+    
+    func testCanSaveProfileWithNameAndSucceed() throws {
+        // Profile Service
+        let profileService: ProfileService = ProfileAPI(urlSession: urlSession)
+        
+        // View Model
+        let sampleData = ProfileModel.ProfileData(id: 0, name: "name", username: "", email: "")
+        let profileVM = ProfileViewModel()
+        profileVM.saveProfile(profile: sampleData)
+        
+        // Profile Editor View
+        let profileEditor = ProfileEditor(profileService: profileService, profileViewModel: profileVM)
+        
+        XCTAssertTrue(profileEditor.canSave)
     }
     
     // MARK: View Tests (Integration Tests)


### PR DESCRIPTION
### Description
Add a validation to enable/disable the save button of the Edit Profile view based on the state of the name field.

Fixes #139 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
In the Edit Profile view, empty the name field and the save button should be disabled.

| Enabled | Disabled |
|---------|----------|
|<img src="https://user-images.githubusercontent.com/8947399/95009748-cb8e5e00-05fa-11eb-93da-cdcf25527331.png" width="250px">| <img src="https://user-images.githubusercontent.com/8947399/95009753-cfba7b80-05fa-11eb-9b05-af358d7987c1.png" width="250px"> |


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
