### PR TITLE
isolate first name and remove white spaces before name if present and…

### DIFF
--- a/mentorship ios/Views/Home/Home.swift
+++ b/mentorship ios/Views/Home/Home.swift
@@ -13,6 +13,7 @@ struct Home: View {
     private var relationsData: UIHelper.HomeScreen.RelationsListData {
         return homeViewModel.relationsListData
     }
+     
     
     func useHomeService() {
         // fetch dashboard and map to home view model
@@ -33,6 +34,24 @@ struct Home: View {
                 self.homeViewModel.firstTimeLoad = false
             }
         }
+    }
+    
+    func getUserFirstName(fullName: String?) -> String {
+         
+        //Return just the first name
+        if let editFullName = fullName ?? "" {
+            
+            //Field validation
+            //get rid of any spaces before the beginning of the name
+            let trimmedFullName = editFullName.trimmingCharacters(in: .whitespaces)
+            
+            if let index = trimmedFullName.firstIndex(of: " ") {
+                let firstName = String(trimmedFullName.prefix(upTo: index))
+                return firstName
+            }
+        }
+         
+        return ""
     }
     
     var body: some View {
@@ -71,7 +90,7 @@ struct Home: View {
             }
             .listStyle(GroupedListStyle())
             .environment(\.horizontalSizeClass, .regular)
-            .navigationBarTitle("Welcome \(self.homeViewModel.userName?.capitalized ?? "")!")
+            .navigationBarTitle("Welcome \(getUserFirstName(fullName: self.homeViewModel.userName?.capitalized))!", displayMode: .inline)
             .navigationBarItems(trailing:
                 NavigationLink(destination: ProfileSummary()) {
                         Image(systemName: ImageNameConstants.SFSymbolConstants.profileIcon)

--- a/mentorship ios/Views/Home/Home.swift
+++ b/mentorship ios/Views/Home/Home.swift
@@ -13,8 +13,17 @@ struct Home: View {
     private var relationsData: UIHelper.HomeScreen.RelationsListData {
         return homeViewModel.relationsListData
     }
-     
     
+    var userFirstName: String {
+        //Return just the first name
+        if let editFullName = self.homeViewModel.userName?.capitalized ?? "" {
+            let trimmedFullName = editFullName.trimmingCharacters(in: .whitespaces)
+            let userNameAsArray = trimmedFullName.components(separatedBy: " ")
+            return userNameAsArray[0]
+        }
+        return ""
+    }
+      
     func useHomeService() {
         // fetch dashboard and map to home view model
         self.homeService.fetchDashboard { home in
@@ -34,24 +43,6 @@ struct Home: View {
                 self.homeViewModel.firstTimeLoad = false
             }
         }
-    }
-    
-    func getUserFirstName(fullName: String?) -> String {
-         
-        //Return just the first name
-        if let editFullName = fullName ?? "" {
-            
-            //Field validation
-            //get rid of any spaces before the beginning of the name
-            let trimmedFullName = editFullName.trimmingCharacters(in: .whitespaces)
-            
-            if let index = trimmedFullName.firstIndex(of: " ") {
-                let firstName = String(trimmedFullName.prefix(upTo: index))
-                return firstName
-            }
-        }
-         
-        return ""
     }
     
     var body: some View {
@@ -90,7 +81,7 @@ struct Home: View {
             }
             .listStyle(GroupedListStyle())
             .environment(\.horizontalSizeClass, .regular)
-            .navigationBarTitle("Welcome \(getUserFirstName(fullName: self.homeViewModel.userName?.capitalized))!", displayMode: .inline)
+            .navigationBarTitle("Welcome \(userFirstName)!", displayMode: .inline)
             .navigationBarItems(trailing:
                 NavigationLink(destination: ProfileSummary()) {
                         Image(systemName: ImageNameConstants.SFSymbolConstants.profileIcon)

--- a/mentorship ios/Views/Home/Home.swift
+++ b/mentorship ios/Views/Home/Home.swift
@@ -15,6 +15,7 @@ struct Home: View {
     }
     
     var userFirstName: String {
+    
         //Return just the first name
         if let editFullName = self.homeViewModel.userName?.capitalized ?? "" {
             let trimmedFullName = editFullName.trimmingCharacters(in: .whitespaces)


### PR DESCRIPTION
… set NavTitle to inline

### Description
In the navigationBarTitle I added call to a function that takes the userName and removes any spaces before the first letter of the name. Then it returns just the first name. I also set displayMode in the navigationBarTitle to "inline" to keep it from truncating long first names. No dependencies.

Fixes # 131

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface
 

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
  
### How Has This Been Tested?
User accounts were created with intentional white spaces before the name.
User accounts were created with very long first names.


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
  
