### PR TITLE
refactored previous func as computed value 

### DIFF
--- a/mentorship ios/Views/Home/Home.swift
+++ b/mentorship ios/Views/Home/Home.swift
@@ -14,6 +14,17 @@ struct Home: View {
         return homeViewModel.relationsListData
     }
     
+    var userFirstName: String {
+    
+        //Return just the first name
+        if let editFullName = self.homeViewModel.userName?.capitalized ?? "" {
+            let trimmedFullName = editFullName.trimmingCharacters(in: .whitespaces)
+            let userNameAsArray = trimmedFullName.components(separatedBy: " ")
+            return userNameAsArray[0]
+        }
+        return ""
+    }
+      
     func useHomeService() {
         // fetch dashboard and map to home view model
         self.homeService.fetchDashboard { home in
@@ -71,7 +82,7 @@ struct Home: View {
             }
             .listStyle(GroupedListStyle())
             .environment(\.horizontalSizeClass, .regular)
-            .navigationBarTitle("Welcome \(self.homeViewModel.userName?.capitalized ?? "")!")
+            .navigationBarTitle("Welcome \(userFirstName)!", displayMode: .inline)
             .navigationBarItems(trailing:
                 NavigationLink(destination: ProfileSummary()) {
                         Image(systemName: ImageNameConstants.SFSymbolConstants.profileIcon)


### PR DESCRIPTION
* refactored previous func as computed value with any errant white spaces removed returning first name also set NavTitle to inline

### Description
Refactored previous func as a computed value that returns first name of user with any errant whit spaces removed. 
NavTitle remains set to displayMode: inline.

Fixes # 131

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface
 
**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
 
 
### How Has This Been Tested?
User accounts were created with intentional white spaces before the name.
User accounts were created with very long first names.


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project


**Code/Quality Assurance Only**


