### PR TITLE
Hide `Add Task` button if current relation is empty to fix #128

### DIFF
--- a/mentorship ios/Views/Relation/Relation.swift
+++ b/mentorship ios/Views/Relation/Relation.swift
@@ -65,6 +65,14 @@ struct Relation: View {
             }
         }
     }
+
+    @ViewBuilder func trailingNavigationBarItem() -> some View {
+        if let id = relationViewModel.currentRelation.id, id != 0 {
+            Button(LocalizableStringConstants.addTask) {
+                self.relationViewModel.addTask.toggle()
+            }
+        } 
+    }
     
     var body: some View {
         NavigationView {
@@ -116,9 +124,7 @@ struct Relation: View {
             }
             .environment(\.horizontalSizeClass, .regular)
             .navigationBarTitle("Current Relation")
-            .navigationBarItems(trailing: Button(LocalizableStringConstants.addTask) {
-                self.relationViewModel.addTask.toggle()
-            })
+            .navigationBarItems(trailing: trailingNavigationBarItem())
             .sheet(isPresented: $relationViewModel.addTask) {
                 AddTask(relationViewModel: self.relationViewModel)
             }


### PR DESCRIPTION
### Description
I have used `@ViewBuilder` attribute to pass the appropriate `View` to the `navigationBarItems(trailing:)` method. Before collecting data from the server the `id` of `currentRelation` is 0 and if the user doesn't have any Relation then the server response for `id` would be nil. This is why I have checked both of the conditions.

Fixes #128

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I have manually tested the screens.

| Has Relation        | No Relation           |
| ------------- |-------------|
| <img src="https://user-images.githubusercontent.com/16666716/96050912-4af21c00-0e9c-11eb-965b-243ca896b86f.png" alt="Simulator Screen Shot" width="250"/>     | <img src="https://user-images.githubusercontent.com/16666716/96049902-8b509a80-0e9a-11eb-92ec-35545cf3c2f6.png" alt="Simulator Screen Shot" width="250"/> |


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
