### PR TITLE
remove default data from RelationView

### DIFF
--- a/mentorship ios.xcodeproj/project.pbxproj
+++ b/mentorship ios.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		839761C1249F821A0020535C /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839761C0249F821A0020535C /* ProfileViewModel.swift */; };
 		839761C3249F83860020535C /* MembersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839761C2249F83860020535C /* MembersViewModel.swift */; };
 		83AA531D249F860F001D6B0B /* UIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AA531C249F860F001D6B0B /* UIHelper.swift */; };
+		892B1E1925BF938C001A4B74 /* EmptyIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892B1E1825BF938C001A4B74 /* EmptyIndicator.swift */; };
 		AA29979BC7A25F0F15EF1EAB /* Pods_mentorship_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B7C6AD7AFF5534C376F1BAF /* Pods_mentorship_ios.framework */; };
 /* End PBXBuildFile section */
 
@@ -243,6 +244,7 @@
 		839761C0249F821A0020535C /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		839761C2249F83860020535C /* MembersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MembersViewModel.swift; sourceTree = "<group>"; };
 		83AA531C249F860F001D6B0B /* UIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHelper.swift; sourceTree = "<group>"; };
+		892B1E1825BF938C001A4B74 /* EmptyIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyIndicator.swift; sourceTree = "<group>"; };
 		A54B8453C53ABE688B6FEF0C /* Pods-mentorship ios-mentorship iosUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mentorship ios-mentorship iosUITests.debug.xcconfig"; path = "Target Support Files/Pods-mentorship ios-mentorship iosUITests/Pods-mentorship ios-mentorship iosUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		A786C8A19E95295DBDC3690A /* Pods-mentorship iosTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mentorship iosTests.debug.xcconfig"; path = "Target Support Files/Pods-mentorship iosTests/Pods-mentorship iosTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B8251B7BB63EBD5A6466B87F /* Pods-mentorship ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mentorship ios.debug.xcconfig"; path = "Target Support Files/Pods-mentorship ios/Pods-mentorship ios.debug.xcconfig"; sourceTree = "<group>"; };
@@ -368,7 +370,6 @@
 				53D4545324CD50F500083215 /* HomeTests.swift */,
 				53A6DDEF24BE52A100D5DFCE /* ProfileTests.swift */,
 				53A6DC8324CDAC7C00E4FE14 /* RelationTests.swift */,
-				53AC6DE624D2BF8700F7FDE3 /* TaskCommentsTests.swift */,
 				53A6DC8524CDC4EF00E4FE14 /* MembersTests.swift */,
 				53A6DC8724CDCBCA00E4FE14 /* SettingsTests.swift */,
 				534B69D924CB6DAE007646E6 /* MockURLProtocol.swift */,
@@ -528,6 +529,7 @@
 				53C0206E249B8D270000BEB5 /* CommonProfileSection.swift */,
 				53FEC16E24D8842200073535 /* SearchNavigation.swift */,
 				53C59E8D24E6B04900EA0DB4 /* SocialSignInButtons.swift */,
+				892B1E1825BF938C001A4B74 /* EmptyIndicator.swift */,
 			);
 			path = UtilityViews;
 			sourceTree = "<group>";
@@ -994,6 +996,7 @@
 				538CD07224ABE9B800F6A665 /* AddTask.swift in Sources */,
 				53C59E8E24E6B04900EA0DB4 /* SocialSignInButtons.swift in Sources */,
 				53F205DD249ADF9200DDE52E /* ProfileEditor.swift in Sources */,
+				892B1E1925BF938C001A4B74 /* EmptyIndicator.swift in Sources */,
 				534AC02D2486D5CB00A34A46 /* BigBoldButtonStyle.swift in Sources */,
 				53D127B1249C956A003B4756 /* ActivityWithText.swift in Sources */,
 				530F44162482752500B1FD0B /* SceneDelegate.swift in Sources */,
@@ -1210,9 +1213,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "mentorship ios/mentorship ios.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"mentorship ios/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4UDSZ3HFA2;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "mentorship ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1221,6 +1225,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.anitab.mentorship;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1232,9 +1237,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "mentorship ios/mentorship ios.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"mentorship ios/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4UDSZ3HFA2;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "mentorship ios/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1243,6 +1249,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.anitab.mentorship;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/mentorship ios/Constants/LocalizableStringConstants.swift
+++ b/mentorship ios/Constants/LocalizableStringConstants.swift
@@ -45,7 +45,7 @@ struct LocalizableStringConstants {
     static let profile = LocalizedStringKey("Profile")
     static let editProfile = LocalizedStringKey("Edit Profile")
     static let addTask = LocalizedStringKey("Add Task")
-    static let noRelationText = LocalizedStringKey("No active relation")
+    static let noActiveRelation = LocalizedStringKey("No active relation")
     static let markComplete = LocalizedStringKey("Mark as complete")
     static let relationRequest = LocalizedStringKey("Relation Request")
     static let notAvailable = LocalizedStringKey("Not available")

--- a/mentorship ios/Constants/LocalizableStringConstants.swift
+++ b/mentorship ios/Constants/LocalizableStringConstants.swift
@@ -45,6 +45,7 @@ struct LocalizableStringConstants {
     static let profile = LocalizedStringKey("Profile")
     static let editProfile = LocalizedStringKey("Edit Profile")
     static let addTask = LocalizedStringKey("Add Task")
+    static let noRelationText = LocalizedStringKey("No active relation")
     static let markComplete = LocalizedStringKey("Mark as complete")
     static let relationRequest = LocalizedStringKey("Relation Request")
     static let notAvailable = LocalizedStringKey("Not available")

--- a/mentorship ios/Views/Relation/Relation.swift
+++ b/mentorship ios/Views/Relation/Relation.swift
@@ -15,6 +15,11 @@ struct Relation: View {
     var endDate: Date {
         return Date(timeIntervalSince1970: relationViewModel.currentRelation.endDate ?? 0)
     }
+
+    var hasRelation: Bool {
+        return relationViewModel.currentRelation.id != nil &&
+            relationViewModel.currentRelation.id != 0
+    }
     
     // use service to fetch relation and tasks
     func fetchRelationAndTasks() {
@@ -69,49 +74,51 @@ struct Relation: View {
     var body: some View {
         NavigationView {
             ZStack {
-                Form {
-                    //Top detail view
-                    VStack(alignment: .leading, spacing: DesignConstants.Form.Spacing.minimalSpacing) {
-                        //mentor/mentee name and end date
-                        HStack {
-                            Text(relationViewModel.personName).font(.title).fontWeight(.heavy)
-                            Spacer()
-                            Text(relationViewModel.personType).font(.title)
-                        }
-                        .foregroundColor(DesignConstants.Colors.subtitleText)
-                        
-                        Text("Ends On: \(DesignConstants.DateFormat.mediumDate.string(from: endDate))")
-                            .font(.callout)
-                        
-                        //divider, adds a line below name and date
-                        Divider()
-                            .background(DesignConstants.Colors.defaultIndigoColor)
-                    }
-                    .listRowBackground(DesignConstants.Colors.formBackgroundColor)
-                    
-                    //Tasks To Do List section
-                    TasksSection(tasks: relationViewModel.toDoTasks, isToDoSection: true, navToTaskComments: true) { task in
-                        //set tapped task
-                        RelationViewModel.taskTapped = task
-                        //show alert for marking as complete confirmation
-                        self.showAlert.toggle()
-                    }
-                    .alert(isPresented: $showAlert) {
-                        Alert(
-                            title: Text(LocalizableStringConstants.markComplete),
-                            primaryButton: .cancel(),
-                            secondaryButton: .default(Text(LocalizableStringConstants.confirm)) {
-                                self.markAsComplete()
-                            })
-                    }
-                    
-                    //Tasks Done List section
-                    TasksSection(tasks: relationViewModel.doneTasks, navToTaskComments: true)
-                }
-                
                 //show activity spinner if in activity
                 if relationViewModel.inActivity {
                     ActivityIndicator(isAnimating: $relationViewModel.inActivity, style: .medium)
+                } else if hasRelation {
+                    Form {
+                        //Top detail view
+                        VStack(alignment: .leading, spacing: DesignConstants.Form.Spacing.minimalSpacing) {
+                            //mentor/mentee name and end date
+                            HStack {
+                                Text(relationViewModel.personName).font(.title).fontWeight(.heavy)
+                                Spacer()
+                                Text(relationViewModel.personType).font(.title)
+                            }
+                            .foregroundColor(DesignConstants.Colors.subtitleText)
+
+                            Text("Ends On: \(DesignConstants.DateFormat.mediumDate.string(from: endDate))")
+                                .font(.callout)
+
+                            //divider, adds a line below name and date
+                            Divider()
+                                .background(DesignConstants.Colors.defaultIndigoColor)
+                        }
+                        .listRowBackground(DesignConstants.Colors.formBackgroundColor)
+
+                        //Tasks To Do List section
+                        TasksSection(tasks: relationViewModel.toDoTasks, isToDoSection: true, navToTaskComments: true) { task in
+                            //set tapped task
+                            RelationViewModel.taskTapped = task
+                            //show alert for marking as complete confirmation
+                            self.showAlert.toggle()
+                        }
+                        .alert(isPresented: $showAlert) {
+                            Alert(
+                                title: Text(LocalizableStringConstants.markComplete),
+                                primaryButton: .cancel(),
+                                secondaryButton: .default(Text(LocalizableStringConstants.confirm)) {
+                                    self.markAsComplete()
+                                })
+                        }
+
+                        //Tasks Done List section
+                        TasksSection(tasks: relationViewModel.doneTasks, navToTaskComments: true)
+                    }
+                } else {
+                    Text(LocalizableStringConstants.noRelationText)
                 }
             }
             .environment(\.horizontalSizeClass, .regular)

--- a/mentorship ios/Views/Relation/Relation.swift
+++ b/mentorship ios/Views/Relation/Relation.swift
@@ -72,7 +72,7 @@ struct Relation: View {
     }
 
     @ViewBuilder func trailingNavigationBarItem() -> some View {
-        if let id = relationViewModel.currentRelation.id, id != 0 {
+        if hasRelation {
             Button(LocalizableStringConstants.addTask) {
                 self.relationViewModel.addTask.toggle()
             }
@@ -82,6 +82,9 @@ struct Relation: View {
     var body: some View {
         NavigationView {
             ZStack {
+                //Screen background color
+                DesignConstants.Colors.formBackgroundColor.edgesIgnoringSafeArea(.all)
+
                 //show activity spinner if in activity
                 if relationViewModel.inActivity {
                     ActivityIndicator(isAnimating: $relationViewModel.inActivity, style: .medium)
@@ -126,7 +129,7 @@ struct Relation: View {
                         TasksSection(tasks: relationViewModel.doneTasks, navToTaskComments: true)
                     }
                 } else {
-                    Text(LocalizableStringConstants.noRelationText)
+                    EmptyIndicator(title: LocalizableStringConstants.noActiveRelation)
                 }
             }
             .environment(\.horizontalSizeClass, .regular)

--- a/mentorship ios/Views/UtilityViews/EmptyIndicator.swift
+++ b/mentorship ios/Views/UtilityViews/EmptyIndicator.swift
@@ -1,0 +1,15 @@
+//
+//  EmptyIndicator.swift
+//  Created on 1/26/21
+//  Created for AnitaB.org Mentorship-iOS 
+//
+
+import SwiftUI
+
+struct EmptyIndicator: View {
+    var title: LocalizedStringKey
+
+    var body: some View {
+        Text(title)
+    }
+}


### PR DESCRIPTION


### Description
If the viewmodel is in Activity mode then only ActivityIndicator will be shown. If there is any relation then the Relation data would be shown. Otherwise, a default text will be shown to indicate an empty relation.

Fixes #144 

### Type of Change:

- Code
- User Interface

### How Has This Been Tested?

I have manually tested the screens.

| Has Relation        | No Relation           |
| ------------- |-------------|
| <img src="https://user-images.githubusercontent.com/16666716/97422478-0b194300-1938-11eb-9df9-e6bfd7830311.png" alt="Simulator Screen Shot" width="250"/>     | <img src="https://user-images.githubusercontent.com/16666716/97422496-11a7ba80-1938-11eb-91c3-2fd92cb7f364.png" alt="Simulator Screen Shot" width="250"/> |


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
